### PR TITLE
datatype: decode 'money' types as Numeric

### DIFF
--- a/src/tds/codec/column_data/money.rs
+++ b/src/tds/codec/column_data/money.rs
@@ -1,18 +1,31 @@
-use crate::{error::Error, sql_read_bytes::SqlReadBytes, ColumnData};
+use crate::{error::Error, numeric::Numeric, sql_read_bytes::SqlReadBytes, ColumnData};
 
+/// Decode 'money' and 'smallmoney' types according to the TDS spec.
+///
+/// See: <https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-tds/1266679d-cd6e-492a-b2b2-3a9ba004196d>.
 pub(crate) async fn decode<R>(src: &mut R, len: u8) -> crate::Result<ColumnData<'static>>
 where
     R: SqlReadBytes + Unpin,
 {
-    let res = match len {
-        0 => ColumnData::F64(None),
-        4 => ColumnData::F64(Some(src.read_i32_le().await? as f64 / 1e4)),
-        8 => ColumnData::F64(Some({
-            let high = src.read_i32_le().await? as i64;
-            let low = src.read_u32_le().await? as f64;
+    /// According to the TDS spec both money types are sent over the wire with
+    /// a scale of 4 (aka ten-thousandth).
+    const SCALE: u8 = 4;
 
-            ((high << 32) as f64 + low) / 1e4
-        })),
+    let res = match len {
+        0 => ColumnData::Numeric(None),
+        4 => {
+            let value = src.read_i32_le().await?;
+            let value = Numeric::new_with_scale(value.into(), SCALE);
+            ColumnData::Numeric(Some(value))
+        }
+        8 => {
+            let high = src.read_i32_le().await?;
+            let low = src.read_u32_le().await?;
+
+            let value = (high as i64) << 32 | (low as i64);
+            let value = Numeric::new_with_scale(value.into(), SCALE);
+            ColumnData::Numeric(Some(value))
+        }
         _ => {
             return Err(Error::Protocol(
                 format!("money: length of {} is invalid", len).into(),

--- a/src/tds/codec/token/token_col_metadata.rs
+++ b/src/tds/codec/token/token_col_metadata.rs
@@ -129,10 +129,10 @@ impl BaseMetaDataColumn {
                 FixedLenType::Int4 => ColumnData::I32(None),
                 FixedLenType::Datetime4 => ColumnData::SmallDateTime(None),
                 FixedLenType::Float4 => ColumnData::F32(None),
-                FixedLenType::Money => ColumnData::F64(None),
+                FixedLenType::Money => ColumnData::Numeric(None),
                 FixedLenType::Datetime => ColumnData::DateTime(None),
                 FixedLenType::Float8 => ColumnData::F64(None),
-                FixedLenType::Money4 => ColumnData::F32(None),
+                FixedLenType::Money4 => ColumnData::Numeric(None),
                 FixedLenType::Int8 => ColumnData::I64(None),
             },
             TypeInfo::VarLenSized(cx) => match cx.r#type() {
@@ -150,7 +150,7 @@ impl BaseMetaDataColumn {
                     4 => ColumnData::F32(None),
                     _ => ColumnData::F64(None),
                 },
-                VarLenType::Money => ColumnData::F64(None),
+                VarLenType::Money => ColumnData::Numeric(None),
                 VarLenType::Datetimen => ColumnData::DateTime(None),
                 #[cfg(feature = "tds73")]
                 VarLenType::Daten => ColumnData::Date(None),
@@ -180,7 +180,7 @@ impl BaseMetaDataColumn {
                 VarLenType::Decimaln => ColumnData::Numeric(None),
                 VarLenType::Numericn => ColumnData::Numeric(None),
                 VarLenType::Floatn => ColumnData::F32(None),
-                VarLenType::Money => ColumnData::F64(None),
+                VarLenType::Money => ColumnData::Numeric(None),
                 VarLenType::Datetimen => ColumnData::DateTime(None),
                 #[cfg(feature = "tds73")]
                 VarLenType::Daten => ColumnData::Date(None),


### PR DESCRIPTION
`f64` in Rust is too imprecise and at the boundaries of the type the value gets rounded.

For example:
```
CREATE TABLE t1 (a money);
INSERT INTO t1 VALUES (-922337203685476.9999);
SELECT * FROM t1;
```
Currently in `tiberius` this returns `-922337203685477.0`