### PR TITLE
Add support for supplying a CA certificate as a PEM string

### DIFF
--- a/src/client/tls_stream/native_tls_stream.rs
+++ b/src/client/tls_stream/native_tls_stream.rs
@@ -15,6 +15,10 @@ pub(crate) async fn create_tls_stream<S: AsyncRead + AsyncWrite + Unpin + Send>(
     let mut builder = TlsConnector::new();
 
     match &config.trust {
+        TrustConfig::CaCertificatePem(cert) => {
+            let cert = Certificate::from_pem(cert.as_bytes())?;
+            builder = builder.add_root_certificate(cert);
+        }
         TrustConfig::CaCertificateLocation(path) => {
             if let Ok(buf) = fs::read(path) {
                 let cert = match path.extension() {

--- a/src/client/tls_stream/opentls_tls_stream.rs
+++ b/src/client/tls_stream/opentls_tls_stream.rs
@@ -15,6 +15,10 @@ pub(crate) async fn create_tls_stream<S: AsyncRead + AsyncWrite + Unpin + Send>(
     let mut builder = TlsConnector::new();
 
     match &config.trust {
+        TrustConfig::CaCertificatePem(cert) => {
+            let cert = Certificate::from_pem(cert.as_bytes())?;
+            builder = builder.add_root_certificate(cert);
+        }
         TrustConfig::CaCertificateLocation(path) => {
             if let Ok(buf) = fs::read(path) {
                 let cert = match path.extension() {


### PR DESCRIPTION
Adds a new function `trust_cert_ca_pem` that will accept a PEM formatted certificate as a string.


Notes
- I had to refresh the certificates in `/docker` to test it, but did not include them in the PR. See the [certs README](https://github.com/MaterializeInc/tiberius/blob/main/docker/certs/README.md) for updating them.
- `native-tls` doesn't work didn't work on macos, `rustls` and `vendored-openssl` are good